### PR TITLE
Feature/handling hard deleted users

### DIFF
--- a/macros/drop_users_stream_table.sql
+++ b/macros/drop_users_stream_table.sql
@@ -1,0 +1,12 @@
+-- This macro drops users_stream from your target schema.
+
+-- We run this macro by invoking it through meltano: `meltano invoke dbt run-operation drop_users_stream_table`
+
+-- Dropping this table ensure we only get the current active users synced from solarvista, so using our dim_user_snapshot
+-- we can track and handle users that have been hard deleted
+{%- macro drop_users_stream_table() -%}
+    {%- set drop_query -%}
+        DROP TABLE {{ target.schema }}.users_stream
+    {%- endset -%}
+    {% do run_query(drop_query) %}
+{%- endmacro -%}

--- a/models/base/dim_user.sql
+++ b/models/base/dim_user.sql
@@ -1,10 +1,39 @@
 {{ config(materialized='table') }}
 
-with users as (
-    select * from "{{var('schema')}}".users_stream
+with user_snapshot as (
+    select * from "{{var('schema')}}".dim_user_snapshot
 ),
 skill_stream as (
     select * from "{{var('schema')}}".skill_stream
+),
+active_users as (
+    select
+        *
+    from user_snapshot
+    where dbt_valid_to isnull 
+),
+deleted_users as (
+    select
+	    *
+    from user_snapshot us
+    where not exists (select *
+                    from  user_snapshot us2
+                    where us2.user_id = us.user_id
+                    and us2.dbt_valid_to > us.dbt_valid_to)
+    and user_id not in (
+    select
+        user_id 
+    from active_users )
+    and dbt_valid_to notnull
+),
+overall_users as (
+    select
+        *
+    from active_users
+    union
+    select
+        *
+    from deleted_users
 ),
 users_with_skills as (
     select 
@@ -12,17 +41,21 @@ users_with_skills as (
         , array_to_json(array_agg(ss.reference)) "skills_reference"
         , array_to_json(array_agg(ss."name")) "skills_name"
     from skill_stream ss, jsonb_array_elements(ss.users)
-    right join users on users.user_id = value->>'id'
+    right join overall_users on overall_users.user_id = value->>'id'
     where value->>'id' notnull
     group by value->>'id'
 ),
 dim_user as (
     select
         {{ dbt_utils.surrogate_key(['user_id']) }} as users_sk
-        , users.*
+        , overall_users.user_id as user_id
+        , overall_users.display_name as display_name
+        , overall_users.email as email
+        , overall_users.is_assignable as is_assignable
+        , case WHEN overall_users.dbt_valid_to notnull then True else False end as is_deleted
         , uws.skills_name
         , uws.skills_reference
-    from users
-    left join users_with_skills uws on uws.skilled_user_id = users.user_id
+    from overall_users
+    left join users_with_skills uws on uws.skilled_user_id = overall_users.user_id
 )
 select * from dim_user

--- a/models/solarvista_live.yml
+++ b/models/solarvista_live.yml
@@ -62,10 +62,15 @@ models:
         tests:
           - accepted_values:
               values: ['Active', 'Closed', 'Cancelled', 'Pending Acceptance']
-
   - name: fact_workitem
     columns:
       - name: work_item_id
+        tests:
+          - unique
+          - not_null
+  - name: dim_user
+    columns:
+      - name: user_id
         tests:
           - unique
           - not_null

--- a/snapshots/dim_user_snapshot.sql
+++ b/snapshots/dim_user_snapshot.sql
@@ -1,0 +1,20 @@
+{% snapshot dim_user_snapshot %}
+{{
+    config(
+      target_schema=var('schema'),
+      unique_key='user_id',
+      strategy='check',
+      check_cols=['user_id'],
+      invalidate_hard_deletes=True,
+    )
+}}
+with users as (
+    select * from "{{var('schema')}}".users_stream
+),
+dim_user_snapshot as (
+    select
+        *
+    from users
+)
+select * from dim_user_snapshot
+{% endsnapshot %}


### PR DESCRIPTION
This completes the trello card `As a user, I want to keep my data intact but still correct and up to date when I remove solarvista users.`

- Added a dim_users_snapshot table with the config to `invalidate_hard_deletes`
- Added a macro to drop the users_stream table, intended to be used just before re-running your tap-solarvista, to actually track what users a missining and therefore deleted.
- Added functionality to dim_user to flag deleted users.
- Added schema test for dim_user to assert that user_id is unique and not null, incase a user is re-instated with the same user_id at a later date.