### PR TITLE
fix/bump-dbt-utils-version

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
 - package: fishtown-analytics/dbt_utils
-  version: 0.6.2
+  version: 0.6.4


### PR DESCRIPTION
Bumped dbt_utils version to 0.6.4 to work with dbt 19.1